### PR TITLE
Update from recent discussions

### DIFF
--- a/text/0000-packages-as-optional-namespaces.md
+++ b/text/0000-packages-as-optional-namespaces.md
@@ -217,6 +217,7 @@ Python has a similar coupling of top-level namespaces and modules with the files
  - How exactly should the Cargo.toml `lib.name` key work in this world, and how does that integrate with `--extern` and `-L` and sysroots?
  - Should we allow renames like `"foo::bar" = { package = "foo_bar", version = "1.0" }` in Cargo.toml?
  - How precisely should this be represented in the index trie?
+ - How we should name the `.crate` file / download URL
 
 # Future possibilities
 

--- a/text/0000-packages-as-optional-namespaces.md
+++ b/text/0000-packages-as-optional-namespaces.md
@@ -220,6 +220,12 @@ Deferred to tracking issue to be resolved pre-stabilization:
 - How precisely should this be represented in the index trie?
 - How we should name the `.crate` file / download URL
 
+Third-parties, like Linux distributions, will need to decide how to encode
+cargo package names in their distribution package names according to their
+individual rules.
+Compared to existing ecosystems with namespaces that they package, the only new
+wrinkle is that there can be 0-1 namespace levels.
+
 # Future possibilities
 
 We can allow multiple layers of nesting if people want it.

--- a/text/0000-packages-as-optional-namespaces.md
+++ b/text/0000-packages-as-optional-namespaces.md
@@ -214,10 +214,11 @@ Python has a similar coupling of top-level namespaces and modules with the files
 
 # Unresolved questions
 
- - How exactly should the Cargo.toml `lib.name` key work in this world, and how does that integrate with `--extern` and `-L` and sysroots?
- - Should we allow renames like `"foo::bar" = { package = "foo_bar", version = "1.0" }` in Cargo.toml?
- - How precisely should this be represented in the index trie?
- - How we should name the `.crate` file / download URL
+Deferred to tracking issue to be resolved pre-stabilization:
+- How exactly should the Cargo.toml `lib.name` key work in this world, and how does that integrate with `--extern` and `-L` and sysroots?
+- Should we allow renames like `"foo::bar" = { package = "foo_bar", version = "1.0" }` in Cargo.toml?
+- How precisely should this be represented in the index trie?
+- How we should name the `.crate` file / download URL
 
 # Future possibilities
 


### PR DESCRIPTION
This adds an unresolved question around `.crate` that recently came up.  So far, the cargo team at least is ok with these being deferred out to the implementation.

I also felt it would be good to acknowledge the plight of Linux distributions and made a best attempt at finding a place for that and capturing it though I don't think we should block this on them as they can find a way to resolve this.